### PR TITLE
Implement fade transitions for tabs

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -24,11 +24,37 @@
 .fade {
   display: none;
   opacity: 0;
-  transition: opacity 0.6s ease-in-out;
+  transition: opacity 0.5s ease-in-out;
 }
 .fade.visible {
   display: block;
   opacity: 1;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+
+.fade-in {
+  animation: fadeIn 0.5s forwards;
+}
+
+.fade-out {
+  animation: fadeOut 0.25s forwards;
 }
 
 

--- a/js/responsiveTabs.js
+++ b/js/responsiveTabs.js
@@ -1,5 +1,26 @@
 let currentTab = "#about";
 
+function fadeIn(el, duration = 500) {
+  if (!el) return;
+  el.style.display = 'block';
+  el.classList.add('fade-in');
+  setTimeout(() => {
+    el.classList.remove('fade-in');
+  }, duration);
+}
+
+function fadeOut(el, duration = 250) {
+  return new Promise(resolve => {
+    if (!el) { resolve(); return; }
+    el.classList.add('fade-out');
+    setTimeout(() => {
+      el.style.display = 'none';
+      el.classList.remove('fade-out');
+      resolve();
+    }, duration);
+  });
+}
+
 function switchWidth() {
   const windowWidth = window.innerWidth;
   const current = document.querySelector(currentTab);
@@ -34,14 +55,21 @@ document.addEventListener('click', function (e) {
     const heading = e.target.closest('.data .heading');
     e.preventDefault();
     if (!heading.classList.contains('active')) {
-      currentTab = '#' + heading.closest('.data').id;
-      const current = document.querySelector(currentTab);
-      document.querySelectorAll('.tabContents .tabData').forEach(el => el.style.display = 'none');
+      const newSection = heading.closest('.data');
+      const newData = newSection.querySelector('.tabData');
+      const oldSection = document.querySelector(currentTab);
+      const oldData = oldSection ? oldSection.querySelector('.tabData') : null;
+      currentTab = '#' + newSection.id;
       document.querySelectorAll('.tabContents .data .heading').forEach(el => el.classList.remove('active'));
-      const h = current.querySelector('.heading');
-      const d = current.querySelector('.tabData');
-      if (h) h.classList.add('active');
-      if (d) d.style.display = '';
+      document.querySelectorAll('.tabContents .tabData').forEach(el => {
+        if (el !== newData && el !== oldData) el.style.display = 'none';
+      });
+      if (oldData && oldData !== newData) {
+        fadeOut(oldData).then(() => fadeIn(newData));
+      } else {
+        fadeIn(newData);
+      }
+      if (heading) heading.classList.add('active');
     }
   } else if (e.target.closest('.Tlinks')) {
     const target = e.target.closest('.Tlinks');
@@ -53,14 +81,21 @@ document.addEventListener('click', function (e) {
     target.classList.add('active');
     target.setAttribute('aria-selected', 'true');
     const tabID = target.id;
+    const newSection = document.querySelector(`section[sid="${tabID}"]`);
+    const oldSection = document.querySelector(currentTab);
     document.querySelectorAll('#tabs .data').forEach(section => {
-      section.style.display = 'none';
+      if (section !== newSection && section !== oldSection) {
+        section.style.display = 'none';
+      }
     });
-    const section = document.querySelector(`section[sid="${tabID}"]`);
-    if (section) {
-      section.style.display = 'block';
-      currentTab = '#' + section.id;
+    if (oldSection && oldSection !== newSection) {
+      fadeOut(oldSection).then(() => {
+        if (newSection) fadeIn(newSection);
+      });
+    } else if (newSection) {
+      fadeIn(newSection);
     }
+    if (newSection) currentTab = '#' + newSection.id;
     document.querySelectorAll('.tabContents .tabData').forEach(el => el.style.display = '');
   }
 });


### PR DESCRIPTION
## Summary
- tweak fade transition speed
- add keyframes and classes for fading elements
- support fading in and out on tab navigation

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68757121831c832eadf509b07902d4ff