### PR TITLE
Fix html-validate issues in index

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
 	<!--Webmention & Pingback -->
 	<link href="https://webmention.io/jaredzimmerman.com/webmention" rel="webmention">
 	<link href="https://webmention.io/jaredzimmerman.com/xmlrpc" rel="pingback">
-    
+
 
 	<!--Theme Color-->
 	<meta content="#424242" name="theme-color">
@@ -34,13 +34,13 @@
 	<!--Description & Keywords-->
 	<meta content="Jared Zimmerman is an award winning product design leader, educator, and speaker" name="description">
     <meta content="product design, leader, educator, speaker" name="keywords">
-    <meta name="fediverse:creator" content="@jaredzimmerman@jaredzimmerman.com" />
-    <meta name="fediverse:creator" content="@jaredzimmerman@social.jaredzimmerman.com" />
+    <meta name="fediverse:creator" content="@jaredzimmerman@jaredzimmerman.com">
+    <meta name="fediverse:creator" content="@jaredzimmerman@social.jaredzimmerman.com">
 
 	<!--Canonical & Author-->
 	<link href="https://www.jaredzimmerman.com" rel="canonical">
 	<link href="https://www.jaredzimmerman.com" rel="author">
-    
+
 
 	<!--Robots & Googlebot -->
 	<meta http-equiv="Content-Security-Policy" content="default-src 'self' https:; script-src 'self' 'unsafe-inline' https://www.googletagmanager.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' https: data:; object-src 'none';">
@@ -164,7 +164,7 @@
 									<p>Jared Zimmerman is an award winning product design leader, educator, and speaker
 										located in San Francisco, CA.</p>
 
-                                   <p>Currently, Jared is VP, Head of Product Design & Research at <a href="https://innovaccer.com" target="_blank" rel="noopener noreferrer">Innovaccer</a></p>     
+                                   <p>Currently, Jared is VP, Head of Product Design &amp; Research at <a href="https://innovaccer.com" target="_blank" rel="noopener noreferrer">Innovaccer</a></p>
 
 
 									<p>He's built products and lead teams at Google, Meta, Wikimedia Foundation, Autodesk,
@@ -190,7 +190,7 @@
 							</div>
 
 
-							<div class="tabData" id="clients">
+							<div class="tabData" id="clientsData">
 								<ul class="clientList">
 									<li>
 										<a href="https://23andme.com/" rel="noopener noreferrer" target="_blank" >23andMe</a>
@@ -418,7 +418,7 @@
 		gtag('config', 'G-5E23NJSBE9', { cookie_flags: 'SameSite=None;Secure;' });
 
 </script>
-    
+
 <script type="application/ld+json">
 {
   "@context": [
@@ -434,7 +434,7 @@
   "birthDate": "1982-08-05",
   "description": "Award-winning product design leader, educator, and speaker",
   "disambiguatingDescription": "Product design leader and speaker",
-  "jobTitle": "VP, Head of Product Design & Research",
+  "jobTitle": "VP, Head of Product Design &amp; Research",
   "workLocation": {
     "@type": "Place",
     "address": {


### PR DESCRIPTION
## Summary
- clean trailing spaces in `index.html`
- convert self-closing meta tags
- encode "Design & Research" text
- change duplicate `id="clients"` to `id="clientsData"`

## Testing
- `npx --yes html-validate index.html && echo VALID`

------
https://chatgpt.com/codex/tasks/task_e_6875d309df54832e81711021160aa762